### PR TITLE
Add check before accepting score

### DIFF
--- a/app.py
+++ b/app.py
@@ -455,6 +455,14 @@ def elo_decay():
     """
     pass
 
+def is_puzzle_valid(puzzle: int):
+    current_puzzle = get_wordle_puzzle(date.today())
+    print(current_puzzle)
+    if current_puzzle <= puzzle:
+        return True
+    else:
+        return False
+
 # ---
 # FastAPI Security Functions
 # ---
@@ -589,11 +597,20 @@ async def add_score(score: Score, current_user: Annotated[User, Depends(get_curr
             data['ordinal'] = player_data['player_ord']
             data['elo_delta'] = player_data['elo_delta']
             data['ordinal_delta'] = player_data['ord_delta']
-        add_entry(config, data)
-        data['player_name'] = player_data['player_name']
-        return data
+        if is_puzzle_valid(data['puzzle']):
+            add_entry(config, data)
+            data['player_name'] = player_data['player_name']
+            return data
+        else:
+            return {
+                'status': 409,
+                'msg': f"The window for submitting Wordle #{data['puzzle']} is closed!"
+            }
     else:
-        return {'status': 409}
+        return {
+            'status': 409,
+            'msg': f"{player_data['player_name']} already submitted Wordle #{data['puzzle']}"
+        }
 
 @app.get('/score/{uuid}')
 async def get_score(uuid, current_user: Annotated[User, Depends(get_current_active_user)], puzzle: int = get_wordle_puzzle(date.today())):

--- a/app.py
+++ b/app.py
@@ -58,7 +58,7 @@ config_file = os.getenv('CONFIG_FILE', 'config.yml')
 with open(config_file, 'r') as f:
     config = yaml.safe_load(f)
 
-model = PlackettLuce(margin=1)
+model = PlackettLuce()
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 

--- a/app.py
+++ b/app.py
@@ -7,8 +7,6 @@ Authors: Jivan RamjiSingh
 TODO:
     P0:
     P1:
-        - Add functionality for generating performance charts
-        - Set margin parameter for PlackettLuce model to account for match skill
         - Add ELO and OpenSkill decay (pending rate determination)
     P2:
         - Lots of documentation
@@ -34,11 +32,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 # ---
 
 import os
-import json
 import yaml
 import logging
-import re
-import math
 import jwt
 from typing import Annotated
 from collections import defaultdict
@@ -63,7 +58,7 @@ config_file = os.getenv('CONFIG_FILE', 'config.yml')
 with open(config_file, 'r') as f:
     config = yaml.safe_load(f)
 
-model = PlackettLuce()
+model = PlackettLuce(margin=1)
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 
@@ -80,6 +75,11 @@ class Player(BaseModel):
     player_name: str
     player_platform: str
     player_uuid: str
+
+class BackfillData(BaseModel):
+    start_puzzle: int
+    end_puzzle: int
+    calc_type: str
 
 class Token(BaseModel):
     access_token: str
@@ -457,7 +457,6 @@ def elo_decay():
 
 def is_puzzle_valid(puzzle: int):
     current_puzzle = get_wordle_puzzle(date.today())
-    print(current_puzzle)
     if current_puzzle <= puzzle:
         return True
     else:
@@ -611,6 +610,39 @@ async def add_score(score: Score, current_user: Annotated[User, Depends(get_curr
             'status': 409,
             'msg': f"{player_data['player_name']} already submitted Wordle #{data['puzzle']}"
         }
+
+@app.post('/backfill-scores')
+async def backfill_scores(backfill_data: BackfillData, current_user: Annotated[User, Depends(get_current_active_user)]):
+    openskill = False
+    elo = False
+
+    match backfill_data.calc_type:
+        case 'openskill':
+            openskill = True
+        case 'elo':
+            elo = True
+        case 'all':
+            openskill = True
+            elo = True
+        case _:
+            return {
+                'status': 400,
+                'msg': 'Field calc_type should be either openskill, elo, or all'
+            }
+    
+    for puzzle in range(backfill_data.start_puzzle, backfill_data.end_puzzle + 1):
+        if check_players(puzzle, puzzle, True):
+            if openskill:
+                calculate_openskill(puzzle)
+            if elo:
+                calculate_match_elo(puzzle)
+        else:
+            pass
+    
+    return {
+        'status': 200,
+        'msg': 'Backfill completed sucessfully.'
+    }
 
 @app.get('/score/{uuid}')
 async def get_score(uuid, current_user: Annotated[User, Depends(get_current_active_user)], puzzle: int = get_wordle_puzzle(date.today())):

--- a/bin/utilities.py
+++ b/bin/utilities.py
@@ -17,24 +17,9 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-import os
-import json
-import yaml
-import logging
 import re
 import math
-import jwt
-from typing import Annotated
-from collections import defaultdict
-from datetime import date, timedelta, timezone, datetime
-from fastapi import FastAPI, Depends, HTTPException, status
-from fastapi.encoders import jsonable_encoder
-from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
-from jwt.exceptions import InvalidTokenError
-from passlib.context import CryptContext
-from pydantic import BaseModel
-from pydantic import BaseModel
-from openskill.models import PlackettLuce
+from datetime import date
 
 def parse_score(score):
     """


### PR DESCRIPTION
This PR encompasses three objectives:

1. Checking if the puzzle being submitted is actually for today's Wordle (we shouldn't accept Wordle's from previous days since they wont be calculated, future dates are acceptable since they will get calculated eventually)
2. Add backfill function (more for testing scoring, but is handy if things were to fail for some reason)
3. Explore adding the margin parameter to the PlackettLuce OpenSkill model (doesn't make sense to include this functionality, a margin of 1 makes little difference to the scores)